### PR TITLE
Pass all container_config object to downstream script

### DIFF
--- a/src/lib_externallogger.cpp
+++ b/src/lib_externallogger.cpp
@@ -87,6 +87,9 @@ public:
       environment[flags.mesos_field_prefix + flags.executor_info_json_field]
                   = jsonExecInfo;
     }
+    // Allow to pass all information to the script
+    JSON::Object containerConfigInfo = JSON::protobuf(containerConfig);
+    environment[flags.mesos_field_prefix + "CONTAINER_CONFIG"] = stringify(containerConfigInfo);
 
     // NOTE: We manually construct a pipe here instead of using
     // `ContainerIO::PIPE` so that the ownership of the FDs is properly


### PR DESCRIPTION
This will allow a script to take better decisions.

For instance, a script could decide to log differently container whose
container_class is DEBUG.

Some users could desire to log other things at startup such as some
information about the container.

Change-Id: I934d1c92bb925a5e2afbfc5db718a6e345575d81